### PR TITLE
prussdrv: add prussdrv_extmem_size

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -128,6 +128,8 @@ extern "C" {
 
     int prussdrv_map_extmem(void **address);
 
+    unsigned int prussdrv_extmem_size(void);
+
     int prussdrv_map_prumem(unsigned int pru_ram_id, void **address);
 
     int prussdrv_map_peripheral_io(unsigned int per_id, void **address);

--- a/pru_sw/app_loader/interface/prussdrv.c
+++ b/pru_sw/app_loader/interface/prussdrv.c
@@ -466,6 +466,10 @@ int prussdrv_map_extmem(void **address)
 
 }
 
+unsigned int prussdrv_extmem_size(void)
+{
+    return prussdrv.extram_map_size;
+}
 
 int prussdrv_map_prumem(unsigned int pru_ram_id, void **address)
 {


### PR DESCRIPTION
I didn't see any other pull requests for this repository, but I hope that there is some way of getting community supplied patches to the PRU loader back to a central location.

Regarding this one, I needed more than the default amount of DDR memory for my PRU program, so if I wasn't careful, the PRU program could overwrite memory that wasn't allocated for it. This patch makes it easy to query the PRU loader for DDR size information before running the PRU program.
