### PR TITLE
Remove debug prints in release builds and return error when fopen/fread fail

### DIFF
--- a/pru_sw/app_loader/interface/prussdrv.c
+++ b/pru_sw/app_loader/interface/prussdrv.c
@@ -668,6 +668,7 @@ int prussdrv_exec_program(int prunum, char *filename)
     fPtr = fopen(filename, "rb");
     if (fPtr == NULL) {
         DEBUG_PRINTF("File %s open failed\n", filename);
+	return -1;
     } else {
         DEBUG_PRINTF("File %s open passed\n", filename);
     }
@@ -686,6 +687,8 @@ int prussdrv_exec_program(int prunum, char *filename)
     if (fileSize !=
         fread((unsigned char *) fileDataArray, 1, fileSize, fPtr)) {
         DEBUG_PRINTF("WARNING: File Size mismatch\n");
+	fclose(fPtr);
+	return -1;
     }
 
     fclose(fPtr);


### PR DESCRIPTION
The first commit makes all of the debug printfs throughout the code disappear for release builds. In general, they were not that helpful and just cluttered the output of other programs. However, two errors were only reported via the debug prints. These were both in prussdrv_exec_program. The second commit adds code to return an error if fopen fails or fread doesn't read enough data.
