### PR TITLE
fix examples broken by recent event wait/clear changes

### DIFF
--- a/pru_sw/example_apps/PRU_PRUtoPRU_Interrupt/PRU_PRUtoPRU_Interrupt.c
+++ b/pru_sw/example_apps/PRU_PRUtoPRU_Interrupt/PRU_PRUtoPRU_Interrupt.c
@@ -172,13 +172,13 @@ int main(void)
     printf("\tINFO: Waiting for HALT command.\r\n");
     prussdrv_pru_wait_event (PRU_EVTOUT_0);
     printf("\tINFO: PRU0 completed transfer.\r\n");
-    prussdrv_pru_clear_event (PRU0_ARM_INTERRUPT);
+    prussdrv_pru_clear_event (PRU_EVTOUT_0, PRU0_ARM_INTERRUPT);
 
     /* Wait until PRU0 has finished execution */
     printf("\t\tINFO: Waiting for HALT command.\r\n");
     prussdrv_pru_wait_event (PRU_EVTOUT_1);
     printf("\t\tINFO: PRU1 completed transfer.\r\n");
-    prussdrv_pru_clear_event (PRU1_ARM_INTERRUPT);
+    prussdrv_pru_clear_event (PRU_EVTOUT_1, PRU1_ARM_INTERRUPT);
 
     /* Check if example passed */
     if ( LOCAL_examplePassed(PRU_NUM1) )

--- a/pru_sw/example_apps/PRU_memAccessPRUDataRam/PRU_memAccessPRUDataRam.c
+++ b/pru_sw/example_apps/PRU_memAccessPRUDataRam/PRU_memAccessPRUDataRam.c
@@ -145,7 +145,7 @@ int main (void)
     printf("\tINFO: Waiting for HALT command.\r\n");
     prussdrv_pru_wait_event (PRU_EVTOUT_0);
     printf("\tINFO: PRU completed transfer.\r\n");
-    prussdrv_pru_clear_event (PRU0_ARM_INTERRUPT);
+    prussdrv_pru_clear_event (PRU_EVTOUT_0, PRU0_ARM_INTERRUPT);
 
     /* Check if example passed */
     if ( LOCAL_examplePassed(PRU_NUM) )

--- a/pru_sw/example_apps/PRU_memAccess_DDR_PRUsharedRAM/PRU_memAccess_DDR_PRUsharedRAM.c
+++ b/pru_sw/example_apps/PRU_memAccess_DDR_PRUsharedRAM/PRU_memAccess_DDR_PRUsharedRAM.c
@@ -159,7 +159,7 @@ int main (void)
     printf("\tINFO: Waiting for HALT command.\r\n");
     prussdrv_pru_wait_event (PRU_EVTOUT_0);
     printf("\tINFO: PRU completed transfer.\r\n");
-    prussdrv_pru_clear_event (PRU0_ARM_INTERRUPT);
+    prussdrv_pru_clear_event (PRU_EVTOUT_0, PRU0_ARM_INTERRUPT);
 
     /* Check if example passed */
     if ( LOCAL_examplePassed(PRU_NUM) )


### PR DESCRIPTION
This fixes #12 as raised by @mention vmayoral.

I'd really like to change the way that the wait/clear stuff is interfaced.  It seems that we should make variants of wait/clear methods that do an auto lookup of the host_interrupt given the system event (instead of necessarily specifiying the host_interrupt.  This can be implemented using the lookup routines that I added earlier to (re)discover the mapping of event/channel/interrupt.
