### PR TITLE
prussdrv: add call to get file descriptor

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -176,6 +176,8 @@ extern "C" {
      * @return the number of times the event has happened. */
     unsigned int prussdrv_pru_wait_event(unsigned int host_interrupt);
 
+    int prussdrv_pru_event_fd(unsigned int host_interrupt);
+
     int prussdrv_pru_send_event(unsigned int eventnum);
 
     /** Clear the specified event and re-enable the host interrupt. */

--- a/pru_sw/app_loader/interface/prussdrv.c
+++ b/pru_sw/app_loader/interface/prussdrv.c
@@ -480,6 +480,14 @@ unsigned int prussdrv_pru_wait_event(unsigned int host_interrupt)
     return event_count;
 }
 
+int prussdrv_pru_event_fd(unsigned int host_interrupt)
+{
+    if (host_interrupt < NUM_PRU_HOSTIRQS)
+        return prussdrv.fd[host_interrupt];
+    else
+        return -1;
+}
+
 int prussdrv_pru_clear_event(unsigned int host_interrupt, unsigned int sysevent)
 {
     unsigned int *pruintc_io = (unsigned int *) prussdrv.intc_base;


### PR DESCRIPTION
This is needed to be able to select(2) or poll(2) on PRU interrupts.

Signed-off-by: Frank Hunleth fhunleth@troodon-software.com
