### PR TITLE
prussdrv: add prussdrv_exec_code function

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -195,6 +195,7 @@ extern "C" {
     int prussdrv_start_irqthread(unsigned int host_interrupt, int priority,
                                  prussdrv_function_handler irqhandler);
 
+    int prussdrv_exec_code(int prunum, const unsigned int *code, int codelen);
 
 #if defined (__cplusplus)
 }

--- a/pru_sw/app_loader/interface/prussdrv.c
+++ b/pru_sw/app_loader/interface/prussdrv.c
@@ -663,14 +663,6 @@ int prussdrv_exec_program(int prunum, const char *filename)
     FILE *fPtr;
     unsigned char fileDataArray[PRUSS_MAX_IRAM_SIZE];
     int fileSize = 0;
-    unsigned int pru_ram_id;
-
-    if (prunum == 0)
-        pru_ram_id = PRUSS0_PRU0_IRAM;
-    else if (prunum == 1)
-        pru_ram_id = PRUSS0_PRU1_IRAM;
-    else
-        return -1;
 
     // Open an File from the hard drive
     fPtr = fopen(filename, "rb");
@@ -701,10 +693,23 @@ int prussdrv_exec_program(int prunum, const char *filename)
 
     fclose(fPtr);
 
+    return prussdrv_exec_code(prunum, (const unsigned int *) fileDataArray, fileSize);
+}
+
+int prussdrv_exec_code(int prunum, const unsigned int *code, int codelen)
+{
+    unsigned int pru_ram_id;
+
+    if (prunum == 0)
+        pru_ram_id = PRUSS0_PRU0_IRAM;
+    else if (prunum == 1)
+        pru_ram_id = PRUSS0_PRU1_IRAM;
+    else
+        return -1;
+
     // Make sure PRU sub system is first disabled/reset
     prussdrv_pru_disable(prunum);
-    prussdrv_pru_write_memory(pru_ram_id, 0,
-                              (unsigned int *) fileDataArray, fileSize);
+    prussdrv_pru_write_memory(pru_ram_id, 0, code, codelen);
     prussdrv_pru_enable(prunum);
 
     return 0;


### PR DESCRIPTION
This adds a helper function for loading PRU code from memory. This is
handy when building the PRU code into the application executable with
a header file generated by "pasm -c".

This is based on similar functions found in various am335x_pru_package
forks.

Signed-off-by: Frank Hunleth fhunleth@troodon-software.com
