### PR TITLE
prussdrv: Remove pthreads dependency

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -49,7 +49,6 @@
 #define _PRUSSDRV_H
 
 #include <sys/types.h>
-#include <pthread.h>
 
 #if defined (__cplusplus)
 extern "C" {
@@ -87,7 +86,6 @@ extern "C" {
 #define PRU_EVTOUT_6            6
 #define PRU_EVTOUT_7            7
 
-    typedef void *(*prussdrv_function_handler) (void *);
     typedef struct __sysevt_to_channel_map {
         short sysevt;
         short channel;
@@ -191,10 +189,6 @@ extern "C" {
     int prussdrv_exit(void);
 
     int prussdrv_exec_program(int prunum, const char *filename);
-
-    int prussdrv_start_irqthread(unsigned int host_interrupt, int priority,
-                                 prussdrv_function_handler irqhandler);
-
 
 #if defined (__cplusplus)
 }

--- a/pru_sw/app_loader/interface/__prussdrv.h
+++ b/pru_sw/app_loader/interface/__prussdrv.h
@@ -204,7 +204,6 @@ typedef struct __prussdrv {
     void *pru1_iram_base;
     void *l3ram_base;
     void *extram_base;
-    pthread_t irq_thread[NUM_PRU_HOSTIRQS];
     int mmap_fd;
     void *pruss_sharedram_base;
     void *pruss_cfg_base;

--- a/pru_sw/app_loader/interface/prussdrv.c
+++ b/pru_sw/app_loader/interface/prussdrv.c
@@ -49,7 +49,6 @@
 
 #include <prussdrv.h>
 #include "__prussdrv.h"
-#include <pthread.h>
 #include <stdio.h>
 
 #ifdef __DEBUG
@@ -652,8 +651,6 @@ int prussdrv_exit()
     for (i = 0; i < NUM_PRU_HOSTIRQS; i++) {
         if (prussdrv.fd[i])
             close(prussdrv.fd[i]);
-        if (prussdrv.irq_thread[i])
-            pthread_join(prussdrv.irq_thread[i], NULL);
     }
     return 0;
 }
@@ -708,27 +705,4 @@ int prussdrv_exec_program(int prunum, const char *filename)
     prussdrv_pru_enable(prunum);
 
     return 0;
-}
-
-int prussdrv_start_irqthread(unsigned int host_interrupt, int priority,
-                             prussdrv_function_handler irqhandler)
-{
-    pthread_attr_t pthread_attr;
-    struct sched_param sched_param;
-    pthread_attr_init(&pthread_attr);
-    if (priority != 0) {
-        pthread_attr_setinheritsched(&pthread_attr,
-                                     PTHREAD_EXPLICIT_SCHED);
-        pthread_attr_setschedpolicy(&pthread_attr, SCHED_FIFO);
-        sched_param.sched_priority = priority;
-        pthread_attr_setschedparam(&pthread_attr, &sched_param);
-    }
-
-    pthread_create(&prussdrv.irq_thread[host_interrupt], &pthread_attr,
-                   irqhandler, NULL);
-
-    pthread_attr_destroy(&pthread_attr);
-
-    return 0;
-
 }

--- a/pru_sw/example_apps/PRU_PRUtoPRU_Interrupt/Makefile
+++ b/pru_sw/example_apps/PRU_PRUtoPRU_Interrupt/Makefile
@@ -6,7 +6,7 @@ BINDIR?=../bin
 
 #CFLAGS+= -Wall -I$(INCDIR_APP_LOADER) -D__DEBUG -O2 -mtune=arm926ej-s -march=armv5te
 CFLAGS+= -I$(INCDIR_APP_LOADER) -D__DEBUG -O2 -mtune=cortex-a8 -march=armv7-a
-LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv -lpthread
+LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv
 OBJDIR=obj
 TARGET=$(BINDIR)/PRU_PRUtoPRU_Interrupt
 

--- a/pru_sw/example_apps/PRU_memAccessPRUDataRam/Makefile
+++ b/pru_sw/example_apps/PRU_memAccessPRUDataRam/Makefile
@@ -5,7 +5,7 @@ INCDIR_APP_LOADER?=../../app_loader/include
 BINDIR?=../bin
 
 CFLAGS+= -Wall -I$(INCDIR_APP_LOADER) -D__DEBUG -O2 -mtune=cortex-a8 -march=armv7-a
-LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv -lpthread
+LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv
 OBJDIR=obj
 TARGET=$(BINDIR)/PRU_memAccessPRUDataRam
 

--- a/pru_sw/example_apps/PRU_memAccess_DDR_PRUsharedRAM/Makefile
+++ b/pru_sw/example_apps/PRU_memAccess_DDR_PRUsharedRAM/Makefile
@@ -5,7 +5,7 @@ INCDIR_APP_LOADER?=../../app_loader/include
 BINDIR?=../bin
 
 CFLAGS+= -Wall -I$(INCDIR_APP_LOADER) -D__DEBUG -O2 -mtune=cortex-a8 -march=armv7-a
-LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv -lpthread
+LDFLAGS+=-L$(LIBDIR_APP_LOADER) -lprussdrv
 OBJDIR=obj
 TARGET=$(BINDIR)/PRU_memAccess_DDR_PRUsharedRAM
 


### PR DESCRIPTION
This change removes the prussdrv_start_irqthread helper function and hence removes the only pthreads dependency in the am335x_pru_package. None of the examples use the function, so the removal of pthreads is propagated through the example Makefiles. While pthreads is almost certainly available on the Beaglebones that use this library, here are a few reasons why this change is a good one.
1. Seeing pthreads on the link line is a immediate warning sign that threading is in use, so it's reasonable to review the library to make sure that it plays well with application code. Since the am335x_pru_package doesn't really use threading internally at all, removing pthreads removes any doubt that a library call will do something unexpected with threads.
2. The API isn't threadsafe, since shared data is not protected by a mutex. It seems a little scary doing much work in the irqthread without careful thought.
3. While the irq_thread provides the looping structure to wait for PRU interrupts, it didn't have a way to pass messages to it. I.e, to exit the thread or to change a parameter for how the application handles the interrupts. I would imagine that many PRU use cases need some kind of message passing to their interrupt handling threads since the PRU provides some ongoing processing rather than a one-off. I addressed passing messages to my PRU interrupt handler by using select(2) and a message pipe, but I would have done it different if I were using Qt or STL. I think threading is better addressed by the application.
4. Removing the pthreads dependency lets the library be used with toolchains that don't include pthreads. As far as I know, this is only needed for custom uclibc builds, but it is conceivable that someone may build a very small Linux system that uses the PRU app_loader.

I'm curious if anyone actually uses irqthread, and if they do, whether it would bother them that much to move the pthread creation calls into their code.
