### PR TITLE
Added changes needed to load binaries generated with TI's C compiler. Credit goes to github user texane.

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -123,6 +123,7 @@ extern "C" {
     int prussdrv_pru_disable(unsigned int prunum);
 
     int prussdrv_pru_enable(unsigned int prunum);
+    int prussdrv_pru_enable_at(unsigned int prunum, size_t addr);
 
     int prussdrv_pru_write_memory(unsigned int pru_ram_id,
                                   unsigned int wordoffset,
@@ -189,8 +190,12 @@ extern "C" {
     int prussdrv_exit(void);
 
     int prussdrv_exec_program(int prunum, const char *filename);
+    int prussdrv_exec_program_at(int prunum, const char *filename, size_t addr);
 
     int prussdrv_exec_code(int prunum, const unsigned int *code, int codelen);
+    int prussdrv_exec_code_at(int prunum, const unsigned int *code, int codelen, size_t addr);
+    int prussdrv_load_data(int prunum, const unsigned int *code, int codelen);
+    int prussdrv_load_datafile(int prunum, const char *filename);
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
This is better explained [here](http://www.embeddedrelated.com/showarticle/603.php) in the "Installing the PRU loader" section. This changes were made by [texane](https://github.com/texane) but I'm sending the pull request so that other people can use this loader with binaries generated with TI's C compiler.
