### PR TITLE
Pasm directory name fixed.

### DIFF
--- a/pru_sw/example_apps/Makefile
+++ b/pru_sw/example_apps/Makefile
@@ -5,7 +5,7 @@ LIBDIR_APP_LOADER?=../../app_loader/lib
 INCDIR_APP_LOADER?=../../app_loader/include
 BINDIR_APPLICATIONS?=../bin
 BINDIR_FW?=bin
-PASM?=../utils/pasm_2
+PASM?=../utils/pasm
 
 all: loaders firmware
 


### PR DESCRIPTION
I do not know why, but in the makefile of the examples the name of PASM directory was apparently wrong.
