### PR TITLE
Make ARM compilation flags configurable via environment variable

### DIFF
--- a/pru_sw/app_loader/interface/Makefile
+++ b/pru_sw/app_loader/interface/Makefile
@@ -21,7 +21,8 @@ SODBGTARGET = $(LIBDIR)/$(TARGET)d.so
 SORELTARGET = $(LIBDIR)/$(TARGET).so
 
 DBGCFLAGS = -g -O0 -D__DEBUG
-RELCFLAGS = -O3 -mtune=cortex-a8 -march=armv7-a
+ARM_COMPILE_FLAGS?= -mtune=cortex-a8 -march=armv7-a
+RELCFLAGS = -O3 $(ARM_COMPILE_FLAGS)
 
 SOURCES = $(wildcard *.c)
 


### PR DESCRIPTION
While developing, I often compile my code (BeagleG) not on the BeagleBone black but on a different host machine to see if it compiles while developing. For that, I need to pass different host compilation flags.
Previously, this would require to manually edit the Makefile; with this change this can be overridden via an environment variable.