### PR TITLE
pasm:  Replace missing directory separator in `#include` for POSIX

### DIFF
--- a/pru_sw/utils/pasm_source/pasm.c
+++ b/pru_sw/utils/pasm_source/pasm.c
@@ -612,12 +612,14 @@ USAGE:
             for(i=0; i<(int)hdr.FileCount; i++)
             {
                 memset( &file, 0, sizeof(DBGFILE_FILE) );
-                if( !strcmp( sfArray[i].SourceBaseDir,"./") ||
+                if( !strcmp( sfArray[i].SourceBaseDir,".") ||
+		    !strcmp( sfArray[i].SourceBaseDir,"./.") ||
                     ((strlen(sfArray[i].SourceName)+strlen(sfArray[i].SourceBaseDir)) >= DBGFILE_NAMELEN_SHORT) )
                     strcpy(file.SourceName,sfArray[i].SourceName);
                 else
                 {
                     strcpy(file.SourceName,sfArray[i].SourceBaseDir);
+                    strcat(file.SourceName,"/");
                     strcat(file.SourceName,sfArray[i].SourceName);
                 }
                 if( fwrite(&file,1,sizeof(DBGFILE_FILE),Outfile) != sizeof(DBGFILE_FILE) )

--- a/pru_sw/utils/pasm_source/path_utils.c
+++ b/pru_sw/utils/pasm_source/path_utils.c
@@ -173,10 +173,10 @@ int get_dirname( const char * filename, char * dir, const size_t sz)
     /*------------------------------------------------------------------------
     LJN: POSIX dirname() does not end the path with a / or \
     ------------------------------------------------------------------------*/
-    if( ( dir[ strlen( dir ) - 1 ] == '/'  )
-     || ( dir[ strlen( dir ) - 1 ] == '\\' ) )
+    if( ( dir[ strlen( dir ) ] == '/'  )
+     || ( dir[ strlen( dir ) ] == '\\' ) )
         {
-        dir[ strlen( dir ) - 1 ] = '\0';
+        dir[ strlen( dir ) ] = '\0';
         }
     #endif
 


### PR DESCRIPTION
Commit be231a82 fixed included files for Windows, but broke POSIX.
The POSIX `dirname()` removes a trailing `/`, but the Windows
equivalents do not.

Commit 731fab64 attempted to fix this by removing the trailing slash,
but broken pointer arithmetic ended up having no effect in almost
every case.

This commit attempts to fix the last fix, and then adds the `/` back
into the path at the correct place.  It also fixes cosmetic cases
where the included file is in the same directory, and the leading `./`
may be omitted.

Fixes #53
