### PR TITLE
added: variant of prussdrv_pru_wait_event() with timeout

### DIFF
--- a/pru_sw/app_loader/include/prussdrv.h
+++ b/pru_sw/app_loader/include/prussdrv.h
@@ -174,6 +174,8 @@ extern "C" {
     /** Wait for the specified host interrupt.
      * @return the number of times the event has happened. */
     unsigned int prussdrv_pru_wait_event(unsigned int host_interrupt);
+    
+    unsigned int prussdrv_pru_wait_event_timeout(unsigned int host_interrupt, int time_us);
 
     int prussdrv_pru_event_fd(unsigned int host_interrupt);
 


### PR DESCRIPTION
Some day I needed a version of prussdrv_pru_wait_event() with a configurable timeout and thought I should share it with you. With the parameter "time_us" of prussdrv_pru_wait_event_timeout() one can configure the timeout in Microseconds.

A return value of -1 indicates an error while waiting for the PRU event. If a timeout occurs the function returns 0. Otherwise the return value behaves like in prussdrv_pru_wait_event()