### PR TITLE
Fix warning/error message format to be standard format.

### DIFF
--- a/pru_sw/utils/pasm_source/pasm.c
+++ b/pru_sw/utils/pasm_source/pasm.c
@@ -1069,9 +1069,14 @@ void Report( SOURCEFILE *ps, int Level, char *fmt, ... )
     else
 	    file = stdout;
 
-    /* Log to stdout or stderr accordingly*/
+    /* Log to stdout or stderr accordingly.
+     * We adhere here to the exact same output format that compilers (gcc,
+     * clang) or other source code processing tool is reporting messages:
+     * <filename>:<line-number>: <message>
+     * This standard format is parsed by default by IDEs and editors
+     * such as emacs or vi than then can jump to error messages easily. */
     if( ps )
-		fprintf(file, "pasm: %s(%d) ",ps->SourceName,ps->CurrentLine);
+		fprintf(file, "%s:%d: ",ps->SourceName,ps->CurrentLine);
 
     if( Level == REP_FATAL )
     {


### PR DESCRIPTION
The standard format for error messages all common compilers
in the unix environment use is
```
  <filename>:<line-number>: <message>
```
This is easily recongized by IDEs to quickly jump to the
source code position.

The previous format was non-standard, so required extensive
configuration for editors to be recognized. So let's keep it
simple.