### PR TITLE
adjust make to work with compiler defaults and avoid FPU error

### DIFF
--- a/pru_sw/app_loader/interface/Makefile
+++ b/pru_sw/app_loader/interface/Makefile
@@ -21,7 +21,7 @@ SODBGTARGET = $(LIBDIR)/$(TARGET)d.so
 SORELTARGET = $(LIBDIR)/$(TARGET).so
 
 DBGCFLAGS = -g -O0 -D__DEBUG
-ARM_COMPILE_FLAGS?= -mtune=cortex-a8 -march=armv7-a
+ARM_COMPILE_FLAGS?= -mtune=cortex-a8 
 RELCFLAGS = -O3 $(ARM_COMPILE_FLAGS)
 
 SOURCES = $(wildcard *.c)


### PR DESCRIPTION
The change herein fixes the following problem on linux kernel 6.17 : 

```
make[1]: Entering directory '/home/debian/am335x_pru_package/pru_sw/app_loader/interface'
gcc -I. -Wall -I../include  -c -g -O0 -D__DEBUG -o debug/prussdrv.o prussdrv.c
ar rc ../lib/libprussdrvd.a debug/prussdrv.o
gcc -I. -Wall -I../include  -c -O3 -mtune=cortex-a8 -march=armv7-a -o release/prussdrv.o prussdrv.c
cc1: error: '-mfloat-abi=hard': selected architecture lacks an FPU
make[1]: *** [Makefile:74: release/prussdrv.o] Error 1
make[1]: Leaving directory '/home/debian/am335x_pru_package/pru_sw/app_loader/interface'
make: *** [Makefile:10: all] Error 2
```